### PR TITLE
"ssl-legacy" and "ciphersuites" options for xe command

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,6 +1,6 @@
 OASISFormat: 0.3
 Name:        xe
-Version:     0.7.0
+Version:     0.8.0
 Synopsis:    A simple command-line interface for xapi
 Authors:     David Scott
 License:     Apache

--- a/_oasis
+++ b/_oasis
@@ -13,5 +13,5 @@ Executable xe
   MainIs:             newcli.ml
   Custom:             true
   Install:            false
-  BuildDepends:       uuidm, unix, re.str, uri, cohttp (>= 0.14.0), cohttp.lwt, lwt, lwt.unix, lwt.ssl, lwt.syntax, cstruct (>= 0.6.0)
+  BuildDepends:       uuidm, unix, re.str, uri, cohttp (>= 0.14.0), cohttp.lwt, lwt, lwt.unix, lwt.ssl, lwt.syntax, cstruct (>= 0.6.0), ssl (>= 0.5.0)
 

--- a/opam
+++ b/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt"
   "ocamlfind"
   "cohttp" {>= "0.14.0"}
-  "ssl"
+  "ssl" {>= "0.5.0"}
   "re"
   "uri"
   "uuidm"

--- a/src/channels.ml
+++ b/src/channels.ml
@@ -124,7 +124,7 @@ let sslctx legacy ciphers =
 
 (* The first call to this sets up the TLS configuration, then in
  * any subsequent calls fd is the only parameter that is used. *)
-let of_ssl_fd ~legacy ?ciphers fd =
+let of_ssl_fd ~legacy ~ciphers fd =
   let really_write_offset = ref 0L in
   Lwt_ssl.ssl_connect fd (sslctx legacy ciphers) >>= fun sock ->
   let read buf =

--- a/src/channels.ml
+++ b/src/channels.ml
@@ -101,8 +101,10 @@ let gen_sslctx legacy ciphers =
      * for this function says, "Note that [SSLv23] disables both SSLv2 and
      * SSLv3 (as opposed to all the protocols)."
      *)
-    (* Disable SSL v2 and v3, and TLSv1.1, leaving only TLSv1.0 and TLSv1.2 *)
-    Ssl.disable_protocols ctx [Ssl.SSLv23; Ssl.TLSv1_1];
+    (* Disable SSL v2 and v3, leaving only TLSv1.0 and TLSv1.1 and TLSv1.2 *)
+    (* We don't need 1.1, but if we add it to the list then 1.2 gets disabled
+     * too: a bug in the Ssl module v0.5.2 (or the libssl it is using) *)
+    Ssl.disable_protocols ctx [Ssl.SSLv23];
   );
   Ssl.set_cipher_list ctx (match ciphers with
     | Some c -> c

--- a/src/channels.ml
+++ b/src/channels.ml
@@ -77,13 +77,54 @@ let of_seekable_fd fd =
     return () in
   return { c with skip }
 
-let sslctx =
-  Ssl.init ();
-  Ssl.create_context Ssl.SSLv23 Ssl.Client_context
+let _ = Ssl.init ()
 
-let of_ssl_fd fd =
+let default_good_ciphers = "!EXPORT:RSA+AES128-SHA256"
+let default_legacy_ciphers = "RSA+AES256-SHA:RSA+AES128-SHA:RSA+RC4-SHA:RSA+DES-CBC3-SHA"
+
+let sslctx_cached = ref None
+
+let gen_sslctx legacy ciphers =
+  let ctx =
+    (* According to the documentation in ssl.mli, here SSLv23 means
+     * "accept all possible protocols (SSLv2 if supported by openssl,
+     *  SSLv3, TLSv1, TLSv1.1 and TLSv1.2)"
+     * whereas TLSv1_2 means "only TLS v1.2 protocol" *)
+    Ssl.create_context
+      (if legacy then Ssl.SSLv23 else Ssl.TLSv1_2)
+      Ssl.Client_context
+  in
+  if legacy then (
+    (* We created the context with all protocols enabled, so we must disable
+     * the ones we do not want. In the Ssl module, SSLv23 has a different
+     * meaning for the disable_protocols function: in ssl.mli the documentation
+     * for this function says, "Note that [SSLv23] disables both SSLv2 and
+     * SSLv3 (as opposed to all the protocols)."
+     *)
+    (* Disable SSL v2 and v3, and TLSv1.1, leaving only TLSv1.0 and TLSv1.2 *)
+    Ssl.disable_protocols ctx [Ssl.SSLv23; Ssl.TLSv1_1];
+  );
+  Ssl.set_cipher_list ctx (match ciphers with
+    | Some c -> c
+    | None -> (if legacy then (default_good_ciphers^":"^default_legacy_ciphers)
+      else default_good_ciphers)
+  );
+  ctx
+
+let sslctx legacy ciphers =
+  match !sslctx_cached with
+    | Some ctx -> ctx
+    | None -> (
+      let ctx = gen_sslctx legacy ciphers in
+      sslctx_cached := Some ctx;
+      ctx
+    )
+
+(* The first call to this sets up the TLS configuration, then in
+ * any subsequent calls fd is the only parameter that is used. *)
+let of_ssl_fd ~legacy ?ciphers fd =
   let really_write_offset = ref 0L in
-  Lwt_ssl.ssl_connect fd sslctx >>= fun sock ->
+  Lwt_ssl.ssl_connect fd (sslctx legacy ciphers) >>= fun sock ->
   let read buf =
     Lwt_ssl.read_bytes sock buf.Cstruct.buffer buf.Cstruct.off buf.Cstruct.len >>= fun n ->
     return (Cstruct.sub buf 0 n) in

--- a/src/newcli.ml
+++ b/src/newcli.ml
@@ -39,6 +39,7 @@ let get_xapiport ssl =
   | Some p -> p
 
 let xeusessl = ref true
+let ssl_legacy = ref false
 let xedebug = ref false
 let xedebugonfail = ref false
 
@@ -141,6 +142,7 @@ let parse_args =
        | "password" -> xapipword := v
        | "passwordfile" -> xapipasswordfile := v
        | "nossl"   -> xeusessl := not(bool_of_string v)
+       | "ssl-legacy" -> ssl_legacy := (bool_of_string v)
        | "debug" -> xedebug := (try bool_of_string v with _ -> false)
        | "debugonfail" -> xedebugonfail := (try bool_of_string v with _ -> false)
        | _ -> raise Not_found);
@@ -155,6 +157,7 @@ let parse_args =
     | "-pw" :: pw :: xs -> Some("password", pw, xs)
     | "-pwf" :: pwf :: xs -> Some("passwordfile", pwf, xs)
     | "--nossl" :: xs -> Some("nossl", "true", xs)
+    | "--ssl-legacy" :: xs -> Some("ssl-legacy", "true", xs)
     | "--debug" :: xs -> Some("debug", "true", xs)
     | "--debug-on-fail" :: xs -> Some("debugonfail", "true", xs)
     | "-h" :: h :: xs -> Some("server", h, xs)
@@ -229,7 +232,7 @@ let open_tcp_ssl host =
   let sockaddr = Lwt_unix.ADDR_INET(host_entry.Lwt_unix.h_addr_list.(0), get_xapiport true) in
   let sock = socket sockaddr in
   Lwt_unix.connect sock sockaddr >>= fun () ->
-  Channels.of_ssl_fd sock
+  Channels.of_ssl_fd ~legacy:!ssl_legacy sock
 
 let open_tcp host =
   if !xeusessl && not(is_localhost host) then (* never use SSL on-host *)

--- a/src/newcli.ml
+++ b/src/newcli.ml
@@ -40,6 +40,7 @@ let get_xapiport ssl =
 
 let xeusessl = ref true
 let ssl_legacy = ref false
+let ciphersuites = ref None
 let xedebug = ref false
 let xedebugonfail = ref false
 
@@ -143,6 +144,7 @@ let parse_args =
        | "passwordfile" -> xapipasswordfile := v
        | "nossl"   -> xeusessl := not(bool_of_string v)
        | "ssl-legacy" -> ssl_legacy := (bool_of_string v)
+       | "ciphersuites" -> ciphersuites := Some v
        | "debug" -> xedebug := (try bool_of_string v with _ -> false)
        | "debugonfail" -> xedebugonfail := (try bool_of_string v with _ -> false)
        | _ -> raise Not_found);
@@ -158,6 +160,7 @@ let parse_args =
     | "-pwf" :: pwf :: xs -> Some("passwordfile", pwf, xs)
     | "--nossl" :: xs -> Some("nossl", "true", xs)
     | "--ssl-legacy" :: xs -> Some("ssl-legacy", "true", xs)
+    | "--ciphersuites" :: c :: xs -> Some("ciphersuites", c, xs)
     | "--debug" :: xs -> Some("debug", "true", xs)
     | "--debug-on-fail" :: xs -> Some("debugonfail", "true", xs)
     | "-h" :: h :: xs -> Some("server", h, xs)
@@ -232,7 +235,7 @@ let open_tcp_ssl host =
   let sockaddr = Lwt_unix.ADDR_INET(host_entry.Lwt_unix.h_addr_list.(0), get_xapiport true) in
   let sock = socket sockaddr in
   Lwt_unix.connect sock sockaddr >>= fun () ->
-  Channels.of_ssl_fd ~legacy:!ssl_legacy sock
+  Channels.of_ssl_fd ~legacy:!ssl_legacy ~ciphers:!ciphersuites sock
 
 let open_tcp host =
   if !xeusessl && not(is_localhost host) then (* never use SSL on-host *)


### PR DESCRIPTION
Based on the changes made for the xe produced by the xen-api repository:
xapi-project/xen-api#2587