### PR TITLE
CA-204263: Rename xe parameter ssl-legacy to allow-ssl-legacy

### DIFF
--- a/src/newcli.ml
+++ b/src/newcli.ml
@@ -39,7 +39,7 @@ let get_xapiport ssl =
   | Some p -> p
 
 let xeusessl = ref true
-let ssl_legacy = ref false
+let allow_ssl_legacy = ref false
 let ciphersuites = ref None
 let xedebug = ref false
 let xedebugonfail = ref false
@@ -143,7 +143,7 @@ let parse_args =
        | "password" -> xapipword := v
        | "passwordfile" -> xapipasswordfile := v
        | "nossl"   -> xeusessl := not(bool_of_string v)
-       | "ssl-legacy" -> ssl_legacy := (bool_of_string v)
+       | "allow-ssl-legacy" -> allow_ssl_legacy := (bool_of_string v)
        | "ciphersuites" -> ciphersuites := Some v
        | "debug" -> xedebug := (try bool_of_string v with _ -> false)
        | "debugonfail" -> xedebugonfail := (try bool_of_string v with _ -> false)
@@ -159,7 +159,7 @@ let parse_args =
     | "-pw" :: pw :: xs -> Some("password", pw, xs)
     | "-pwf" :: pwf :: xs -> Some("passwordfile", pwf, xs)
     | "--nossl" :: xs -> Some("nossl", "true", xs)
-    | "--ssl-legacy" :: xs -> Some("ssl-legacy", "true", xs)
+    | "--allow-ssl-legacy" :: xs -> Some("allow-ssl-legacy", "true", xs)
     | "--ciphersuites" :: c :: xs -> Some("ciphersuites", c, xs)
     | "--debug" :: xs -> Some("debug", "true", xs)
     | "--debug-on-fail" :: xs -> Some("debugonfail", "true", xs)
@@ -235,7 +235,7 @@ let open_tcp_ssl host =
   let sockaddr = Lwt_unix.ADDR_INET(host_entry.Lwt_unix.h_addr_list.(0), get_xapiport true) in
   let sock = socket sockaddr in
   Lwt_unix.connect sock sockaddr >>= fun () ->
-  Channels.of_ssl_fd ~legacy:!ssl_legacy ~ciphers:!ciphersuites sock
+  Channels.of_ssl_fd ~legacy:!allow_ssl_legacy ~ciphers:!ciphersuites sock
 
 let open_tcp host =
   if !xeusessl && not(is_localhost host) then (* never use SSL on-host *)


### PR DESCRIPTION
Calling the parameter ssl-legacy means it's impossible to set the host
field Host.ssl_legacy via the CLI - xe consumes the parameter rather
than passing it on to xapi.

This is based on John Else's commit in the xen-api repository:
3aa417f12c1739b2f74b9ea1ee507d727fb6c272
